### PR TITLE
Upgrade kafka-clients dependency for Kafka 4.x compatibility

### DIFF
--- a/all-actors/pom.xml
+++ b/all-actors/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>3.4.0</version>
+        <version>${kafka.version}</version>
         <exclusions>
             <exclusion>
                 <groupId>org.xerial.snappy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <guice.version>5.1.0</guice.version>
         <slf4j.version>2.0.13</slf4j.version>
+        <kafka.version>3.7.1</kafka.version>
         <logback.version>1.4.14</logback.version>
         <netty.version>4.1.112.Final</netty.version>
     </properties>

--- a/sb-telemetry-utils/pom.xml
+++ b/sb-telemetry-utils/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.4.0</version>
+            <version>${kafka.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
## Summary

This PR upgrades the kafka-clients dependency to a version compatible with Kafka 4.x.